### PR TITLE
si existe por lo menos una factura pagada dentro del total de factura…

### DIFF
--- a/classes/workflow.class.php
+++ b/classes/workflow.class.php
@@ -734,7 +734,7 @@ class Workflow extends Servicio
                 $value['saldo'] =  $value['total']-$value['payment'];
                 if($value["saldo"] > 1)
                 {
-                    $value["class"] = "#ff0000";
+                    $value["class"] = $value['payment']>0 ? "#FC0":"#ff0000";
                     $noComplete++;
                 }
                 else{

--- a/templates/lists/report-servicio.tpl
+++ b/templates/lists/report-servicio.tpl
@@ -34,9 +34,10 @@
 								{else}
 										background-color:{$instanciaServicio.class};
 								{/if}
-								{if $instanciaServicio.class == '#00ff00'}
+								{if $instanciaServicio.class == '#00ff00' || $instanciaServicio.class == '#FC0'}
 								color: #000000; {else}
-								color: #ffffff; {/if}
+								color: #ffffff;
+								{/if}
 								font-weight: bold
 								">
 						{if $instanciaServicio.class != '#000000'}


### PR DESCRIPTION
…s mensual, se debe usar un color que indique que no estan liquidadas todas las facturas, quitar el rojo por que confunde y se piensa que todo el mes se debe la cantidad mostrada.