### PR TITLE
envio de correo log por edicion multiple de servicio, de momento solo…

### DIFF
--- a/classes/personal.class.php
+++ b/classes/personal.class.php
@@ -1205,6 +1205,14 @@ function SubordinadosDetails()
         }
         return $idPersons;
     }
+    public function getCurrentUser(){
+        $this->Util()->DB()->setQuery('SELECT * FROM personal WHERE personalId="'.$_SESSION['User']['userId'].'" ');
+        $row= $this->Util()->DB()->GetRow();
+        if($_SESSION['User']['tipoPers']=='Admin'){
+            $row['name'] = "Administrador de sistema";
+        }
+        return $row;
+    }
     
 }
 

--- a/classes/util.class.php
+++ b/classes/util.class.php
@@ -1425,6 +1425,9 @@ function HandleMultipages($page,$total,$link,$items_per_page=0,$pagevar="p"){
 	}
     function ConvertToLineal($array=array(),$field){
         $newArray = array();
+        if(!is_array($array))
+            $array = [];
+
         foreach($array as $k=>$val)
             if($field=='email'){
                if($this->Util()->ValidateEmail($val[$field]))

--- a/templates/molds/body-email-multiple.tpl
+++ b/templates/molds/body-email-multiple.tpl
@@ -1,0 +1,4 @@
+<div class="fieldBold">
+    <p>La siguiente razon social :  {$contrato.name} del cliente {$contrato.nameContact}</p>
+    <p>ha sido modificada por el colaborador {$currentUser.name}</p>
+</div>

--- a/templates/molds/pdf-log-multiple-operation.tpl
+++ b/templates/molds/pdf-log-multiple-operation.tpl
@@ -104,7 +104,8 @@
         <meta http-equiv="Content-type" content="text/html; charset=UTF-8">
     </head>
 <body>
-<p><b>Se han realizado multiples cambios en los servicios de la siguiente razon social :</b></p>
+    {*Complemento de pagos*}
+    {include file="{$DOC_ROOT}/templates/molds/body-email-multiple.tpl"}
     <table cellpadding="0" cellspacing="0" class="tableFullWidth">
         <tr>
             <td class="fieldBoldBackground alignJustify">Cliente</td>


### PR DESCRIPTION
… enviar a nivel supervisor hasta socio.

Controlar por medio de numeros los niveles de roles, es decir
numero 1 agrupar socio,coordinador, 2 los gerentes, esto servira para cuando se envie correos  pasar ese parametro que indique a partir de que niveles tomar en cuenta.