### PR TITLE
usuarios con allow_visualize_any_contract = '1' debe encontrar a todo…

### DIFF
--- a/classes/personal.class.php
+++ b/classes/personal.class.php
@@ -1130,7 +1130,7 @@ function SubordinadosDetailsAddPass()
     {
         global $User;
         $idPersons = [];
-        if ( (int)$User["level"] == 1|| $this->showAll) {
+        if ( (int)$User["level"] == 1|| $this->showAll || $this->accessAnyContract() === '1') {
             if ($filtro['responsableCuenta'] == 0) {
                 $this->setActive(1);
                 $socios = $this->ListSocios();


### PR DESCRIPTION
…s los subordinados como si fuera de nivel 1, eso solo puede suceder al obtener los subordinados(se hace mas que nada para listar los totals al pie de pagina de reporte de bonos.)