### PR TITLE
CORRECCIONES

### DIFF
--- a/properties/config_style_cell.php
+++ b/properties/config_style_cell.php
@@ -18,7 +18,7 @@ $global_config_style_cell = array(
     ),
     'style_currency' => array(
         'numberformat' => [
-            'code' => PHPExcel_Style_NumberFormat::FORMAT_NUMBER,
+            'code' => PHPExcel_Style_NumberFormat::FORMAT_NUMBER_COMMA_SEPARATED1,
         ],
         'borders' => array(
             'allborders' => array(
@@ -55,7 +55,7 @@ $global_config_style_cell = array(
     ),
     'style_currency_total_por_responsable' => array(
         'numberformat' => [
-            'code' => PHPExcel_Style_NumberFormat::FORMAT_NUMBER,
+            'code' => PHPExcel_Style_NumberFormat::FORMAT_NUMBER_COMMA_SEPARATED1,
         ],
         'fill' => array(
             'type' => PHPExcel_Style_Fill::FILL_SOLID,
@@ -87,7 +87,7 @@ $global_config_style_cell = array(
     ),
     'style_general_col' => array(
         'numberformat' => [
-            'code' => PHPExcel_Style_NumberFormat::FORMAT_NUMBER,
+            'code' => PHPExcel_Style_NumberFormat::FORMAT_NUMBER_COMMA_SEPARATED1,
         ],
         'fill' => array(
             'type' => PHPExcel_Style_Fill::FILL_SOLID,


### PR DESCRIPTION
1. Quitar fila de porcentaje de bonos, solo se deja bono entregado

2. La base para el calculo de crecimiento siempre
sera ENERO. es decir
crecimiento mes corriente = (monto devengando mes corriente / monto devengado mes enero) -100%

3.Si un servicio es secundario no debe tener costo, si trae costo actual resetearlo a cero(con esto resolvemos el tema de trimestral que no debe sumar).
nota: se da por hecho que si un servicio no tiene la configuracion de ser primario, es secundario por default,
esto se realiza desde el apartado de catalogos de TIPOS DE SERVICIO.

4.El monto del bono esta condicionado de solo si debe aparecer cuando el monto trabajado es igual
al monto devengando del mes corriente, de lo contrario poner cero.
Nota: El monto viene dado desde la configuracion de roles > monto por categoria.

5. El porcentaje de efectividad es calculado con INGRESO TRABAJADO / INGRESO DEVENGANDO

6. Cantidades en formato de millar

CONFLICTO EN EFECTIVIDAD Y BONOS ENTREGADOS
Te entiendo perfectamente, que si existe por lo menos un servicio primario y/o secundario no trabajado y sin costo(en caso de un primario)
no deberia contar la efectividad como 100%, ademas de no entregar el bono. pero en lo que respecta al porcentaje de efectividad es
dificil procesarlo por que el total devengado y trabajado llegan a coincidir.

SOLUCION EN BONOS ENTREGADOS
En la entrega de bonos propongo la siguiente solucion, evaluar la cantidad de worflows en verde, de ser igual al numero de workflows abiertos
en el mes se entrega bono, de lo contrario no.(esta correcion ya la implemente.)

en los totales por grupo de supervisor, se hace la suma de los bonos entregados por cada responsable