### PR TITLE
Pass 'false' flag to getRowsBySheet in Bono class

### DIFF
--- a/classes/bono.class.php
+++ b/classes/bono.class.php
@@ -73,7 +73,7 @@ class Bono extends Personal
             $this->setPersonalId($sub['jefeInmediato']);
             $cad['jefe'] = $this->InfoWhitRol();
 
-            $propios_sub    = $this->getRowsBySheet($sub, $name_view, $filtro);
+            $propios_sub    = $this->getRowsBySheet($sub, $name_view, $filtro, false);
             $cad['propios'] = $propios_sub;
             $this->setPersonalId($sub['personalId']);
             $childs             = $this->GetCascadeSubordinates();


### PR DESCRIPTION
Updated the call to getRowsBySheet to include an explicit 'false' as the fourth argument, ensuring the method is invoked with the intended parameters.