### PR TITLE
Exclude 'asociado' variants from operativos filter

### DIFF
--- a/classes/personal.class.php
+++ b/classes/personal.class.php
@@ -1532,7 +1532,8 @@ class Personal extends Main
                $responsablesPropios = json_decode($var['responsables'], true);
 
                $operativos = array_filter($result, function($item) {
-                   return !in_array($item['departamento'], AREAS_NO_OPERATIVAS);
+                   return !in_array($item['departamento'], AREAS_NO_OPERATIVAS)
+                          && !in_array(mb_strtolower($item['departamento']), ['asociado', 'asociada', 'asociados', 'asociadas']);
                });
 
                $directoresOperativos = array_map(function($item) {


### PR DESCRIPTION
Updated the operativos filter to exclude departments named 'asociado', 'asociada', 'asociados', and 'asociadas' (case-insensitive) in addition to AREAS_NO_OPERATIVAS. This ensures these department variants are not considered operativos.