### PR TITLE
Add communication and associate responsibles to service report

### DIFF
--- a/ajax/report-servicio.php
+++ b/ajax/report-servicio.php
@@ -92,7 +92,9 @@ switch($_POST["type"])
 
 						$deptoId = $serv['departamentoId'];
 						$serv['responsable'] = $con['resDepName'][$deptoId];
-						$serv['supervisadoBy'] = $personal->findSupervisor($con['resDepId'][$deptoId]);
+						$serv['resComunicacion'] = $con['resComunicacion'][$deptoId];
+						$serv['resAsociado'] = $con['resAsociado'];
+						//$serv['supervisadoBy'] = $personal->findSupervisor($con['resDepId'][$deptoId]);
 						if($formValues['atrasados'])
 						{
 							$atrasados = $instanciaServicio->getInstanciaAtrasado($serv['servicioId'],$year,$serv['inicioOperaciones'],$isParcial);
@@ -127,7 +129,8 @@ switch($_POST["type"])
 							$card["nameContact"] = $cliente["nameContact"];
 							$card["tipoPersonal"] = $servicio["responsable"]["tipoPersonal"];
 							$card["responsable"] = $servicio["responsable"];
-                            $card["supervisadoBy"] = $servicio["supervisadoBy"];
+							$card["resAsociado"] = $servicio["resAsociado"];
+							$card["resComunicacion"] = $servicio["resComunicacion"];
 							$card["name"] = $contract["name"];
                             $card["contractId"] = $contract["contractId"];
                             $card["anio"] = $year;

--- a/classes/contractRep.class.php
+++ b/classes/contractRep.class.php
@@ -108,8 +108,45 @@ class ContractRep extends Main
             if($encontrado == false &&!$skip) {
                 continue;
             }
-            $res['resDepName'] =  $this->encargadosCustomKey('departamentoId', 'name', $res['contractId']);
-            $res['resDepId'] =  $this->encargadosCustomKey('departamentoId', 'personalId', $res['contractId']);
+            $responsables = $this->encargadosArea($res['contractId']);
+          
+            $responsablesXnombreDepartamento = [];
+            $responsablesNombre = [];
+            $responsablesId = [];
+            $responsablesComunicacion = [];
+            
+            foreach($responsables as $responsable) {
+
+                $responsablesXnombreDepartamento[$responsable['departamento']] =  $responsable['name'];
+                $responsablesNombre[$responsable['departamentoId']] = $responsable['name'];
+                $responsablesId[$responsable['departamentoId']] = $responsable['personalId'];
+            }
+
+            $res['resAsociado'] = '';
+            if(isset($responsablesXnombreDepartamento['Asociado']))
+                $res['resAsociado'] = $responsablesXnombreDepartamento['Asociado'];
+
+            foreach(DEPARTAMENTOS_TIPO_GERENCIA as $depGerencia) {
+                $depPrincipal = $depGerencia['principal'];
+                $depSecundario = $depGerencia['secundario'];
+
+                $responsablePrincipal = current(array_filter($responsables, function($resp) use ($depPrincipal) {
+                    return $resp['departamento'] == $depPrincipal;
+                }));
+                $responsableSecundario = current(array_filter($responsables, function($resp) use ($depSecundario) {
+                    return $resp['departamento'] == $depSecundario;
+                }));
+
+                
+                if($responsableSecundario && !empty($responsableSecundario['name'])) {
+                    $responsablesComunicacion[$responsableSecundario['departamentoId']] = $responsablePrincipal['name'] ?? '';
+                }
+            }
+            
+            $res['resDepName'] =  $responsablesNombre;
+            $res['resDepId'] =  $responsablesId;
+            $res['resComunicacion'] = $responsablesComunicacion;
+
             if(in_array($res["contractId"], explode(',', CONTRACTS_EXECPTION)))
                 $noInclude="";
             //Checamos Servicios

--- a/templates/lists/report-servicio.tpl
+++ b/templates/lists/report-servicio.tpl
@@ -3,8 +3,9 @@
 	<tr>
 		<th align="center" width="60">Cliente</th>
 		<th align="center" width="60">Razon Social</th>
-		<th align="center" width="60">C. Asignado</th>
-		<th align="center" width="60">Supervisor</th>
+		<th align="center" width="60">Encargado de servicio</th>
+		<th align="center" width="60">Resp. de comunicación</th>
+		<th align="center" width="60">Asociado</th>
 		<th align="center" width="50">Ene</th>
 		<th align="center" width="50">Feb</th>
 		<th align="center" width="50">Mar</th>
@@ -26,7 +27,7 @@
 		{foreach from=$cleanedArray item=item key=key}
 		{if $item.isRowCobranza && (in_array(210,$permissions) ||$User.isRoot)}
 			<tr>
-				<td colspan="4" align="center"><b>Total cobranza mensual</b></td>
+				<td colspan="5" align="center"><b>Total cobranza mensual</b></td>
 				{foreach from=$item.instanciasServicio item=instanciaServicio}
                     {if $instanciaServicio.class == '#000000'}
                         <td style="text-align: center;">
@@ -66,8 +67,9 @@
 		<tr>
     		<td align="center" class="" title="">{$item.nameContact}</td>
     		<td align="center" class="" title="">{$item.name}</td>
-			<td align="center" class="" title="{$item.responsable}">{$item.responsable}</td>
-			<td align="center" class="" title="{$item.supervisadoBy}">{$item.supervisadoBy}</td>
+			<td align="center" class="" title="{$item.responsable}">{if $item.responsable} {$item.responsable} {else} Responsable no configurado {/if}</td>
+			<td align="center" class="" title="{$item.resComunicacion}">{if $item.resComunicacion} {$item.resComunicacion} {else} Responsable no configurado {/if}</td>
+			<td align="center" class="" title="{$item.resAsociado}">{if $item.resAsociado} {$item.resAsociado} {else} Responsable no configurado {/if}</td>
 				{foreach from=$item.instanciasServicio item=instanciaServicio name=instancias}
 					<td align="center"
 					  class="
@@ -95,7 +97,7 @@
 						{/if}
 					</td>
 				{/foreach}
-			{if $instanciaServicio.instanciaServicioId && (in_array(248,$permissions)||$User.isRoot)}
+			{if $item.instanciasServicio && (in_array(248,$permissions)||$User.isRoot)}
 				<td>
 					<a href="javascript:;" class="spanDownloadFiles spanAll" title="Descargar archivos anual" data-id="{$item.servicioId}" data-month="" data-type="downloadFilesYear" data-contrato="{$item.contractId}" data-year="{$item.anio}">
 						<img src="{$WEB_ROOT}/images/icons/downFile.png" class="no-clickable">
@@ -106,7 +108,7 @@
 		{/if}
 		{foreachelse}
 		<tr>
-			<td colspan="{if in_array(248,$permissions)||$User.isRoot}17{else}16{/if}">Ning&uacuten registro encontrado</td>
+			<td colspan="{if in_array(248,$permissions)||$User.isRoot}18{else}16{/if}" style="text-align: center;">Ning&uacuten registro encontrado</td>
 		</tr>
 		{/foreach}
 </tbody>


### PR DESCRIPTION
Extended service report to include 'Responsable de comunicación' and 'Asociado' fields alongside the existing responsible. Updated backend logic to fetch and provide these new responsibles, and modified the template to display them in the report table. The supervisor field was removed in favor of the new responsibles.