### PR TITLE
Fix table cell tag in report-ingresos.tpl

### DIFF
--- a/templates/lists/report-ingresos.tpl
+++ b/templates/lists/report-ingresos.tpl
@@ -32,7 +32,7 @@
         <td align="center">${$servicio.costo|number_format:2}</td>
         <td align="center">${$servicio.costoVisual}</td>
         {foreach from=$puestos item=puesto key=keyPuesto}
-            <th align="center" width="60">{if $servicio[$puesto.name] eq ''}--{else}{$servicio[$puesto.name]} {/if}</th>
+            <td align="center" width="60">{if $servicio[$puesto.name] eq ''}--{else}{$servicio[$puesto.name]} {/if}</td>
         {/foreach}
     </tr>
     {/foreach}


### PR DESCRIPTION
Replaces incorrect <th> tag with <td> for service position cells to ensure proper table structure and semantics.