### PR TITLE
Remove max_execution_time setting in Excel class

### DIFF
--- a/classes/excel.class.php
+++ b/classes/excel.class.php
@@ -6,7 +6,6 @@ class Excel
     {
         // Configurar límites PHP para grandes volúmenes
         ini_set('memory_limit', '4096M');
-        ini_set('max_execution_time', 300);
         
         if ($debug === false) {
             $debug = false;


### PR DESCRIPTION
Eliminated the ini_set('max_execution_time', 300) call from the Excel class constructor, possibly to allow scripts to run without time restrictions for large data processing.