### PR TITLE
Add Excel export for ingresos report with new filters

### DIFF
--- a/changes_db/create_sp_reporte_ingreso_2025.sql
+++ b/changes_db/create_sp_reporte_ingreso_2025.sql
@@ -1,0 +1,314 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_reporte_ingreso_anual`$$
+
+CREATE PROCEDURE `sp_reporte_ingreso_anual`(
+    IN p_anio INT,
+    IN p_personal_id INT,
+    IN p_departamento_id INT,
+    IN p_cliente_nombre VARCHAR(255),
+    IN p_empresa_nombre VARCHAR(255),
+    IN p_mes_limite INT
+)
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE subordinados_list TEXT DEFAULT '';
+    
+    -- Si se especifica un personal, obtener todos sus subordinados
+    IF p_personal_id IS NOT NULL THEN
+        -- Inicializar con el personal principal
+        SET subordinados_list = CONCAT(p_personal_id, ',');
+        
+        -- Variables para el bucle recursivo
+        SET @nivel = 0;
+        SET @nuevos_encontrados = 1;
+        
+        -- Bucle para encontrar subordinados recursivamente
+        WHILE @nuevos_encontrados > 0 AND @nivel < 10 DO
+            SET @nuevos_encontrados = 0;
+            SET @query = CONCAT('SELECT GROUP_CONCAT(personalId) INTO @nuevos_subordinados FROM personal WHERE jefeInmediato IN (', TRIM(TRAILING ',' FROM subordinados_list), ') AND FIND_IN_SET(personalId, "', subordinados_list, '") = 0');
+            
+            PREPARE stmt FROM @query;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+            
+            IF @nuevos_subordinados IS NOT NULL AND @nuevos_subordinados != '' THEN
+                SET subordinados_list = CONCAT(subordinados_list, @nuevos_subordinados, ',');
+                SET @nuevos_encontrados = 1;
+            END IF;
+            
+            SET @nivel = @nivel + 1;
+        END WHILE;
+        
+        -- Limpiar la última coma
+        SET subordinados_list = TRIM(TRAILING ',' FROM subordinados_list);
+    END IF;
+    
+    -- Query principal del reporte
+    SELECT 
+        trim(c.nameContact) AS cliente,
+        trim(ct.name) AS empresa,
+        COALESCE(trim(p.name), 'Sin Encargado') AS encargado,
+        trim(ts.nombreServicio) AS servicio,
+        s.status AS estatus,
+        trim(d.departamento) AS departamento,
+        trim(ts.periodicidad) AS periodicidad,
+        
+        -- Enero
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 1 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 1 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 1), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 1), 0)
+            ELSE 0
+        END AS enero,
+        
+        -- Febrero
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 2 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 2 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 2), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 2), 0)
+            ELSE 0
+        END AS febrero,
+        
+        -- Marzo
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 3 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 3 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 3), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 3), 0)
+            ELSE 0
+        END AS marzo,
+        
+        -- Abril
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 4 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 4 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 4), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 4), 0)
+            ELSE 0
+        END AS abril,
+        
+        -- Mayo
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 5 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 5 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 5), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 5), 0)
+            ELSE 0
+        END AS mayo,
+        
+        -- Junio
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 6 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 6 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 6), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 6), 0)
+            ELSE 0
+        END AS junio,
+        
+        -- Julio
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 7 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 7 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 7), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 7), 0)
+            ELSE 0
+        END AS julio,
+        
+        -- Agosto
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 8 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 8 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 8), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 8), 0)
+            ELSE 0
+        END AS agosto,
+        
+        -- Septiembre
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 9 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 9 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 9), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 9), 0)
+            ELSE 0
+        END AS septiembre,
+        
+        -- Octubre
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 10 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 10 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 10), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 10), 0)
+            ELSE 0
+        END AS octubre,
+        
+        -- Noviembre
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 11 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 11 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 11), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 11), 0)
+            ELSE 0
+        END AS noviembre,
+        -- Diciembre
+        CASE 
+            WHEN p_mes_limite IS NOT NULL AND 12 > p_mes_limite THEN 0
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND MONTH(s.lastDateWorkflow) >= 12 THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 12), 0)
+            WHEN s.status != 'bajaParcial' THEN
+                COALESCE((SELECT SUM(ins.costoWorkflow) 
+                         FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio AND MONTH(ins.date) = 12), 0)
+            ELSE 0
+        END AS diciembre
+        
+    FROM servicio s
+    INNER JOIN contract ct ON s.contractId = ct.contractId
+    INNER JOIN customer c ON ct.customerId = c.customerId
+    INNER JOIN tipoServicio ts ON s.tipoServicioId = ts.tipoServicioId
+    LEFT JOIN departamentos d ON ts.departamentoId = d.departamentoId
+    LEFT JOIN contractPermiso cp ON ct.contractId = cp.contractId 
+        AND cp.departamentoId = d.departamentoId
+    LEFT JOIN personal p ON cp.personalId = p.personalId
+    
+    WHERE 
+        -- Solo servicios activos o en bajaParcial
+        s.status IN ('activo', 'bajaParcial')
+        
+        -- Solo tipos de servicio primarios
+        AND ts.is_primary = 1
+        
+        -- Filtro de año (obligatorio)
+        AND EXISTS (
+            SELECT 1 FROM instanciaServicio ins 
+            WHERE ins.servicioId = s.servicioId 
+            AND YEAR(ins.date) = p_anio
+        )
+        
+        -- Filtro de personal (si se especifica)
+        AND (
+            p_personal_id IS NULL 
+            OR p.personalId = p_personal_id
+            OR (subordinados_list != '' AND FIND_IN_SET(p.personalId, subordinados_list) > 0)
+        )
+        
+        -- Filtro de departamento (si se especifica)
+        AND (p_departamento_id IS NULL OR (d.departamentoId IS NOT NULL AND d.departamentoId = p_departamento_id))
+        
+        -- Filtro de nombre cliente (si se especifica)
+        AND (
+            p_cliente_nombre IS NULL 
+            OR c.nameContact LIKE CONCAT('%', p_cliente_nombre, '%')
+        )
+        
+        -- Filtro de nombre empresa (si se especifica)
+        AND (
+            p_empresa_nombre IS NULL 
+            OR ct.name LIKE CONCAT('%', p_empresa_nombre, '%')
+        )
+    
+    HAVING (
+        -- Solo filas donde al menos un monto mensual es mayor a 0
+        GREATEST(
+            COALESCE(Enero, 0), COALESCE(Febrero, 0), COALESCE(Marzo, 0), COALESCE(Abril, 0),
+            COALESCE(Mayo, 0), COALESCE(Junio, 0), COALESCE(Julio, 0), COALESCE(Agosto, 0),
+            COALESCE(Septiembre, 0), COALESCE(Octubre, 0), COALESCE(Noviembre, 0), COALESCE(Diciembre, 0)
+        ) > 0
+    )
+    
+    ORDER BY 
+        c.nameContact,
+        ct.name,
+        ts.nombreServicio;
+    
+END$$
+
+DELIMITER ;
+
+-- Ejemplo de uso:
+-- CALL sp_reporte_ingreso_anual(2025, NULL, NULL, NULL, NULL); -- Todos los registros del 2025
+-- CALL sp_reporte_ingreso_anual(2025, 123, NULL, NULL, NULL); -- Filtrado por personal ID 123 y sus subordinados
+-- CALL sp_reporte_ingreso_anual(2025, NULL, 5, 'Juan', 'Empresa ABC'); -- Con múltiples filtros

--- a/changes_db/create_sp_reporte_montos_departamentos.sql
+++ b/changes_db/create_sp_reporte_montos_departamentos.sql
@@ -1,0 +1,230 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_reporte_montos_por_departamento`$$
+
+CREATE PROCEDURE `sp_reporte_montos_por_departamento`(
+    IN p_anio INT,
+    IN p_mes INT,
+    IN p_personal_id INT,
+    IN p_departamento_id INT,
+    IN p_cliente_nombre VARCHAR(255),
+    IN p_empresa_nombre VARCHAR(255)
+)
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE subordinados_list TEXT DEFAULT '';
+    DECLARE sql_query TEXT DEFAULT '';
+    DECLARE departamento_columns TEXT DEFAULT '';
+    DECLARE done_cursor INT DEFAULT FALSE;
+    DECLARE v_departamentoId INT;
+    DECLARE v_departamento VARCHAR(255);
+    
+    -- Declarar cursor después de todas las variables
+    DECLARE cur_departamentos CURSOR FOR 
+        SELECT departamentoId, departamento FROM temp_departamentos ORDER BY departamento;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done_cursor = TRUE;
+    
+    -- Si se especifica un personal, obtener todos sus subordinados
+    IF p_personal_id IS NOT NULL THEN
+        -- Inicializar con el personal principal
+        SET subordinados_list = CONCAT(p_personal_id, ',');
+        
+        -- Variables para el bucle recursivo
+        SET @nivel = 0;
+        SET @nuevos_encontrados = 1;
+        
+        -- Bucle para encontrar subordinados recursivamente
+        WHILE @nuevos_encontrados > 0 AND @nivel < 10 DO
+            SET @nuevos_encontrados = 0;
+            SET @query = CONCAT('SELECT GROUP_CONCAT(personalId) INTO @nuevos_subordinados FROM personal WHERE jefeInmediato IN (', TRIM(TRAILING ',' FROM subordinados_list), ') AND FIND_IN_SET(personalId, "', subordinados_list, '") = 0');
+            
+            PREPARE stmt FROM @query;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+            
+            IF @nuevos_subordinados IS NOT NULL AND @nuevos_subordinados != '' THEN
+                SET subordinados_list = CONCAT(subordinados_list, @nuevos_subordinados, ',');
+                SET @nuevos_encontrados = 1;
+            END IF;
+            
+            SET @nivel = @nivel + 1;
+        END WHILE;
+        
+        -- Limpiar la última coma
+        SET subordinados_list = TRIM(TRAILING ',' FROM subordinados_list);
+    END IF;
+    
+    -- Crear tabla temporal para almacenar departamentos únicos
+    CREATE TEMPORARY TABLE temp_departamentos (
+        departamentoId INT,
+        departamento VARCHAR(255),
+        INDEX idx_dept (departamentoId)
+    );
+    
+    -- Obtener todos los departamentos existentes (tengan o no servicios)
+    INSERT INTO temp_departamentos (departamentoId, departamento)
+    SELECT DISTINCT d.departamentoId, d.departamento
+    FROM departamentos d
+    WHERE (p_departamento_id IS NULL OR d.departamentoId = p_departamento_id)
+    ORDER BY d.departamento;
+    
+    -- Step 1: Pre-calculate the total costs per service, per year/month
+    CREATE TEMPORARY TABLE temp_servicio_costos AS
+    SELECT
+        s.contractId,
+        s.tipoServicioId,
+        ts.departamentoId,
+        ts.is_primary,
+        CASE
+            WHEN s.status = 'bajaParcial' AND YEAR(s.lastDateWorkflow) = p_anio AND 
+                 (p_mes IS NULL OR MONTH(s.lastDateWorkflow) >= p_mes) THEN
+                CASE 
+                    WHEN p_mes IS NULL THEN
+                        -- Todo el año hasta lastDateWorkflow
+                        (SELECT SUM(ins.costoWorkflow) FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio 
+                         AND MONTH(ins.date) <= MONTH(s.lastDateWorkflow))
+                    ELSE
+                        -- Desde enero hasta el mes indicado, pero respetando lastDateWorkflow
+                        (SELECT SUM(ins.costoWorkflow) FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio 
+                         AND MONTH(ins.date) >= 1 
+                         AND MONTH(ins.date) <= LEAST(p_mes, MONTH(s.lastDateWorkflow)))
+                END
+            WHEN s.status != 'bajaParcial' THEN
+                CASE 
+                    WHEN p_mes IS NULL THEN
+                        -- Todo el año
+                        (SELECT SUM(ins.costoWorkflow) FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio)
+                    ELSE
+                        -- Desde enero hasta el mes indicado
+                        (SELECT SUM(ins.costoWorkflow) FROM instanciaServicio ins 
+                         WHERE ins.servicioId = s.servicioId 
+                         AND YEAR(ins.date) = p_anio 
+                         AND MONTH(ins.date) >= 1 
+                         AND MONTH(ins.date) <= p_mes)
+                END
+            ELSE 0
+        END AS costo_total
+    FROM servicio s
+    INNER JOIN tipoServicio ts ON s.tipoServicioId = ts.tipoServicioId
+    WHERE s.status IN ('activo', 'bajaParcial') AND ts.is_primary = 1;
+    
+    -- Create aggregated table to avoid multiple references
+    CREATE TEMPORARY TABLE temp_costos_agrupados AS
+    SELECT 
+        contractId,
+        departamentoId,
+        SUM(costo_total) as total_departamento
+    FROM temp_servicio_costos 
+    GROUP BY contractId, departamentoId;
+    
+    -- Step 2: Build the dynamic columns using cursor to avoid GROUP_CONCAT limits
+    -- Aumentar el límite de GROUP_CONCAT temporalmente
+    SET SESSION group_concat_max_len = 1000000;
+    
+    -- Inicializar columnas dinámicas
+    SET departamento_columns = '';
+    
+    OPEN cur_departamentos;
+    read_loop: LOOP
+        FETCH cur_departamentos INTO v_departamentoId, v_departamento;
+        IF done_cursor THEN
+            LEAVE read_loop;
+        END IF;
+        
+        -- Agregar columna para este departamento
+        IF departamento_columns != '' THEN
+            SET departamento_columns = CONCAT(departamento_columns, ', ');
+        END IF;
+        
+        SET departamento_columns = CONCAT(departamento_columns, 
+            'COALESCE(SUM(CASE WHEN tca.departamentoId = ', v_departamentoId, 
+            ' THEN tca.total_departamento ELSE 0 END), 0) AS `', REPLACE(v_departamento, ' ', '_'), '`');
+            
+    END LOOP;
+    CLOSE cur_departamentos;
+    
+    -- Si no hay departamentos, establecer columna por defecto
+    IF departamento_columns IS NULL OR departamento_columns = '' THEN
+        SET departamento_columns = '0 AS Ningun_Departamento';
+    END IF;
+    
+    -- Construir la consulta dinámica
+    SET sql_query = CONCAT('
+        SELECT 
+            trim(c.nameContact) AS cliente,
+            trim(ct.name) AS empresa,
+            ', departamento_columns, '
+        FROM contract ct
+        INNER JOIN customer c ON ct.customerId = c.customerId
+        LEFT JOIN temp_costos_agrupados tca ON ct.contractId = tca.contractId
+        WHERE ct.contractId IN (
+                SELECT DISTINCT contractId FROM temp_servicio_costos
+            )');
+    
+    -- Agregar filtros condicionales
+    IF p_personal_id IS NOT NULL THEN
+        SET sql_query = CONCAT(sql_query, '
+            AND EXISTS (
+                SELECT 1 FROM contractPermiso cp
+                INNER JOIN personal p ON cp.personaId = p.personalId
+                WHERE cp.contractId = ct.contractId
+                AND (
+                    p.personalId = ', p_personal_id, '
+                    OR ("', subordinados_list, '" != "" AND FIND_IN_SET(p.personalId, "', subordinados_list, '") > 0)
+                )
+            )');
+    END IF;
+    
+    IF p_departamento_id IS NOT NULL THEN
+        SET sql_query = CONCAT(sql_query, '
+            AND ct.contractId IN (
+                SELECT contractId FROM temp_servicio_costos 
+                WHERE departamentoId = ', p_departamento_id, '
+            )');
+    END IF;
+    
+    IF p_cliente_nombre IS NOT NULL THEN
+        SET sql_query = CONCAT(sql_query, '
+            AND c.nameContact LIKE "%', p_cliente_nombre, '%"');
+    END IF;
+    
+    IF p_empresa_nombre IS NOT NULL THEN
+        SET sql_query = CONCAT(sql_query, '
+            AND ct.name LIKE "%', p_empresa_nombre, '%"');
+    END IF;
+    
+    -- Agregar GROUP BY y ORDER BY
+    SET sql_query = CONCAT(sql_query, '
+        GROUP BY ct.contractId, c.customerId, c.nameContact, ct.name
+        HAVING COALESCE(SUM(tca.total_departamento), 0) > 0
+        ORDER BY c.nameContact ASC, ct.name ASC');
+    
+    -- Ejecutar la consulta dinámica
+    SET @final_query = sql_query;
+    PREPARE stmt FROM @final_query;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+    
+    -- Restaurar el límite original de GROUP_CONCAT
+    SET SESSION group_concat_max_len = 1024;
+    
+    -- Limpiar tablas temporales
+    DROP TEMPORARY TABLE temp_departamentos;
+    DROP TEMPORARY TABLE temp_servicio_costos;
+    DROP TEMPORARY TABLE temp_costos_agrupados;
+    
+END$$
+
+DELIMITER ;
+
+-- Ejemplo de uso:
+-- CALL sp_reporte_montos_por_departamento(2025, NULL, NULL, NULL, NULL, NULL); -- Todos los registros del 2025 por departamento
+-- CALL sp_reporte_montos_por_departamento(2025, 6, NULL, NULL, NULL, NULL); -- Acumulado de enero a junio del 2025
+-- CALL sp_reporte_montos_por_departamento(2025, NULL, 123, NULL, NULL, NULL); -- Filtrado por personal y sus subordinados
+-- CALL sp_reporte_montos_por_departamento(2025, 3, NULL, 5, 'Juan', 'Empresa ABC'); -- Acumulado enero-marzo con múltiples filtros

--- a/js/report-ingresos.js
+++ b/js/report-ingresos.js
@@ -150,7 +150,7 @@ function SuggestUser2()
 
 function doSearch(){
 	
-	$('type').value = "search";
+	$('type').value = "reporteIngresosToExcel";
 
 	new Ajax.Request(WEB_ROOT+'/ajax/report-ingresos.php',
 	{
@@ -165,8 +165,9 @@ function doSearch(){
 			var response = transport.responseText || "no response text";
 			var splitResponse = response.split("[#]");
 
-			$("loading").style.display = "none";						
-			$('contenido').innerHTML = splitResponse[1];
+			$("loading").style.display = "none";			
+			window.location = response			
+			//$('contenido').innerHTML = splitResponse[1];
 		},
 		onFailure: function(){ alert('Something went wrong...') }
 	});

--- a/modules/report-ingresos.php
+++ b/modules/report-ingresos.php
@@ -18,6 +18,7 @@
 
   	$personals = $personal->Enumerate();
 	$departamentos = $departamentos->Enumerate();
+	$smarty->assign("year", date('Y'));
 
 	$smarty->assign("personals", $personals);
 	$smarty->assign("departamentos", $departamentos);

--- a/templates/forms/search-report-ingresos.tpl
+++ b/templates/forms/search-report-ingresos.tpl
@@ -1,19 +1,20 @@
  <div align="center"  id="divForm">
  
 <form name="frmSearch" id="frmSearch" action="" method="post">
-<input type="hidden" name="type" id="type" value="search" />
+<input type="hidden" name="type" id="type" value="reporteIngresosToExcel" />
 <input type="hidden" name="customerId" id="customerId" value="0" />
 <input type="hidden" name="contractId" id="contractId" value="0" />
-<table width="60%" align="center">
+<table width="90%" align="center">
 <tr style="background-color:#CCC">
-    <td colspan="6" bgcolor="#CCCCCC" align="center"><b>Filtro de B&uacute;squeda</b></td>
+    <td colspan="8" bgcolor="#CCCCCC" align="center"><b>Filtro de B&uacute;squeda</b></td>
 </tr>
 <tr>
     <td align="center">Cliente:</td>
     <td align="center">Raz&oacute;n Social:</td>
     <td align="center">Responsable:</td>
-    <td align="center">Incluir Subordinados:</td>
     <td align="center">Departamento:</td>
+    <td align="center">Mes:</td>
+    <td align="center">Año:</td>
 </tr>
 <tr>	
     <td align="center" style="padding-left: 5px; padding-right: 5px">
@@ -34,17 +35,34 @@
 		</td>
         <td align="center" style="padding-left: 5px; padding-right: 5px">
             {include file="{$DOC_ROOT}/templates/forms/comp-filter-personal.tpl"}
-		</td>    
-		<td align="center" style="padding-left: 5px; padding-right: 5px">
-			<input name="deep" id="deep" type="checkbox" value="1" style="width: 90%;"/>
-		</td>     	
+		</td>       	
 		<td align="center" style="padding-left: 5px; padding-right: 5px">
             {include file="{$DOC_ROOT}/templates/forms/comp-filter-dep.tpl"}
 		</td>
+		<td align="center">
+			<select name="period" id="period"  class="largeInput"  style="width: 90%;">
+				<option value="">Todos</option>
+				<option value="1">Enero</option>
+				<option value="2">Febrero</option>
+				<option value="3">Marzo</option>
+				<option value="4">Abril</option>
+				<option value="5">Mayo</option>
+				<option value="6">Junio</option>
+				<option value="7">Julio</option>
+				<option value="8">Agosto</option>
+				<option value="9">Septiembre</option>
+				<option value="10">Octubre</option>
+				<option value="11">Noviembre</option>
+				<option value="12">Diciembre</option>
+			</select>
+		</td>
+		<td align="center">
+			{include file="{$DOC_ROOT}/templates/forms/comp-filter-year.tpl"}
+		</td>
 </tr>        
 <tr>
-    <td align="center" colspan="5">
-        <div style="margin: 0 415px 0 415px">
+    <td style="text-align: center;" colspan="6">
+        <div style="margin: 0 500px 0 500px">
         <a class="button_grey" id="btnBuscar" onclick="doSearch()"><span>Buscar</span></a>
         </div>
     </td>


### PR DESCRIPTION
Implemented a new 'reporteIngresosToExcel' action to generate a two-sheet Excel report (Resumen and Reporte detallado) using new stored procedures for department and annual income summaries. Added SQL procedures for dynamic department and annual income aggregation with support for filters (year, month, responsible, department, client, company). Updated the search form and JS to support year and month filters and trigger the Excel export.